### PR TITLE
Profile의 id 제거 및 user_id를 User의 id(PK)로 변경, 불필요한 import 제거

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Eye, EyeOff, Mail, Lock, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/app/providers/AuthProvider';
 import Link from 'next/link';

--- a/app/providers/AuthProvider.tsx
+++ b/app/providers/AuthProvider.tsx
@@ -6,7 +6,6 @@ import { User } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
 
 interface Profile {
-  id: string;
   name: string;
   modified_at: string;
   created_at: string;

--- a/app/setprofile/page.tsx
+++ b/app/setprofile/page.tsx
@@ -2,9 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { User, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/app/providers/AuthProvider';
 import { supabase } from '@/lib/supabase';

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Eye, EyeOff, Mail, Lock, User, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/app/providers/AuthProvider';
 import Link from 'next/link';

--- a/lib/authValidator.ts
+++ b/lib/authValidator.ts
@@ -22,7 +22,11 @@ export function isPasswordMatch(password: string, confirmPassword: string): bool
 }
 
 export async function isNameDuplicated(name: string): Promise<boolean> {
-  const { data, error } = await supabase.from('profiles').select('id').eq('name', name).single();
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('user_id')
+    .eq('name', name)
+    .single();
   // data가 있으면 중복, 없으면 중복 아님
   return !!data;
 }


### PR DESCRIPTION
## 📌 PR 제목

Profile의 id 제거 및 user_id를 User의 id(PK)로 변경, 불필요한 import 제거

## ✨ 주요 변경 사항

- Supabase profiles 테이블에서 기존 기본키(id) 제거

- user_id를 기본키로 설정하여 users.id와 1:1 식별관계로 변경

- 사용되지 않는 import 제거

---

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 실행 테스트 완료
- [x] 코드 스타일(Prettier 등) 확인 및 적용
- [x] 불필요한 콘솔/주석 제거

---

## 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| (캡처)  | (캡처)  |

---

## 기타 참고 사항 (선택)

- Profile.id 제거로 인해 기존에 해당 필드를 사용하던 코드 수정 필요 (user_id로 대체)
- 기존에 Profile.user_id를 사용하던 코드는 영향 없음
