### PR TITLE
후기 페이지네이션 적용

### DIFF
--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -31,6 +31,14 @@ import ReviewCard from '@/components/reviews/ReviewCard';
 import ReviewList from '@/components/reviews/ReviewList';
 import ReviewForm from '@/components/reviews/ReviewForm';
 import ReviewSearchBar from '@/components/reviews/ReviewSearchBar';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '@/components/ui/pagination';
 
 type Review = {
   id: string;
@@ -292,10 +300,7 @@ export default function ReviewsPage() {
       alert('후기 수정이 완료되었습니다.');
 
       // 후기 목록 새로고침
-      const newData = await fetchReviews();
-      if (newData) {
-        setReviews(newData);
-      }
+      await fetchReviews(currentPage);
 
       // 수정 모드 종료
       setEditingReviewId(null);
@@ -311,30 +316,50 @@ export default function ReviewsPage() {
     }
   };
 
-  // 후기 데이터 가져오기 함수
-  const fetchReviews = async () => {
-    const { data, error } = await supabase.from('review').select(`
-      id,
-      content,
-      score,
-      created_at,
-      user_id,
-      travels: travel_id(
-        name_kr
-      ),
-      review_img(
-        img_url
-      )
-    `);
+  const REVIEWS_PER_PAGE = 10;
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
 
+  const fetchReviews = async (page: number) => {
+    setIsLoading(true);
+    const from = (page - 1) * REVIEWS_PER_PAGE;
+    const to = from + REVIEWS_PER_PAGE - 1;
+    const { data, error, count } = await supabase
+      .from('review')
+      .select(
+        `
+        id,
+        content,
+        score,
+        created_at,
+        user_id,
+        travels:travel_id(
+          name_kr
+        ),
+        review_img(
+          img_url
+        )
+      `,
+        { count: 'exact' }
+      )
+      .range(from, to)
+      .order('created_at', { ascending: false });
     if (error) {
       alert('리뷰 데이터를 불러오지 못했습니다.');
-      return null;
+      setIsLoading(false);
+      return;
     }
-    console.log(data);
-
-    return (data as Review[]) || [];
+    setReviews(data || []);
+    setFilteredReviews(data || []);
+    setTotalCount(count || 0);
+    setIsLoading(false);
   };
+
+  useEffect(() => {
+    fetchReviews(currentPage);
+  }, [currentPage]);
+
+  const totalPages = Math.ceil(totalCount / REVIEWS_PER_PAGE);
 
   // 후기 삭제 함수
   const handleDeleteReview = async (reviewId: string) => {
@@ -388,12 +413,7 @@ export default function ReviewsPage() {
 
       alert('후기가 성공적으로 삭제되었습니다.');
       // 후기 목록 새로고침
-      const newData = await fetchReviews();
-      if (newData) {
-        setReviews(newData);
-      } else {
-        alert('후기 목록을 새로고침하는데 실패했습니다.');
-      }
+      await fetchReviews(currentPage);
     } catch (error) {
       alert('후기 삭제 중 오류가 발생했습니다.');
       console.error('Delete error:', error);
@@ -501,10 +521,7 @@ export default function ReviewsPage() {
 
       // 후기 목록 새로고침
       try {
-        const newData = await fetchReviews();
-        if (newData) {
-          setReviews(newData);
-        }
+        await fetchReviews(currentPage);
       } catch (error) {
         console.error('후기 목록 새로고침 실패:', error);
         // 새로고침 실패해도 폼은 초기화
@@ -632,6 +649,33 @@ export default function ReviewsPage() {
           onEditSubmit={handleEditReview}
           onEditCancel={() => setEditingReviewId(null)}
         />
+
+        {totalPages > 1 && (
+          <div className="mt-8 flex justify-center">
+            <Pagination>
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious onClick={() => setCurrentPage((p) => Math.max(1, p - 1))} />
+                </PaginationItem>
+                {[...Array(totalPages)].map((_, idx) => (
+                  <PaginationItem key={idx}>
+                    <PaginationLink
+                      isActive={currentPage === idx + 1}
+                      onClick={() => setCurrentPage(idx + 1)}
+                    >
+                      {idx + 1}
+                    </PaginationLink>
+                  </PaginationItem>
+                ))}
+                <PaginationItem>
+                  <PaginationNext
+                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/reviews/ReviewCard.tsx
+++ b/components/reviews/ReviewCard.tsx
@@ -51,9 +51,9 @@ export default function ReviewCard({
   onEditCancel,
 }: ReviewCardProps) {
   return (
-    <div className="flex flex-row items-stretch">
+    <div className="bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow border border-gray-100 flex flex-col md:flex-row overflow-hidden">
       {/* 이미지 영역 */}
-      <div className="w-40 flex-shrink-0 flex items-center justify-center bg-gray-100">
+      <div className="md:w-40 w-full flex-shrink-0 flex items-center justify-center bg-gray-50 p-4">
         <img
           src={
             review.review_img && review.review_img.length > 0
@@ -61,259 +61,251 @@ export default function ReviewCard({
               : 'https://exbimetzhyeddpkjnlyt.supabase.co/storage/v1/object/public/reviewimg/tmp/tmp.jpeg'
           }
           alt="여행 사진"
-          className="w-36 h-36 object-cover rounded-lg"
+          className="w-32 h-32 object-cover rounded-lg border"
         />
       </div>
       {/* 텍스트 영역 */}
       <div className="flex-1 flex flex-col justify-between p-4">
-        <CardHeader className="p-0 pb-2">
-          <div className="flex items-start justify-between">
-            <div className="flex items-center space-x-3">
-              <Avatar>
-                <AvatarImage
-                  src="https://exbimetzhyeddpkjnlyt.supabase.co/storage/v1/object/public/reviewimg/tmp/human-vector.jpg"
-                  className="w-10 h-10 rounded-full object-cover transition hover:shadow-md hover:border-blue-300"
-                  alt="유저 아바타"
-                />
-              </Avatar>
-              <div>
-                <div className="flex items-center space-x-2">
-                  <h3 className="font-semibold">{userName}</h3>
-                </div>
-              </div>
-              <div className="flex items-center mt-2">
-                <Badge className="flex items-center gap-1 px-3 py-1 bg-blue-50 text-blue-700 font-medium rounded-full shadow-sm transition-colors duration-200 cursor-default hover:bg-blue-100">
-                  <MapPin className="w-4 h-4 text-blue-400" />
-                  {review.travels.name_kr}
-                </Badge>
-              </div>
+        <div className="flex items-center gap-3 mb-2">
+          <Avatar>
+            <AvatarImage
+              src="https://exbimetzhyeddpkjnlyt.supabase.co/storage/v1/object/public/reviewimg/tmp/human-vector.jpg"
+              className="w-10 h-10 rounded-full object-cover transition hover:shadow-md hover:border-blue-300"
+              alt="유저 아바타"
+            />
+          </Avatar>
+          <div>
+            <div className="font-semibold text-base">{userName}</div>
+            <div className="flex items-center gap-2 mt-1">
+              <Badge className="bg-blue-50 text-blue-700 flex items-center gap-1 px-3 py-1 font-medium rounded-full shadow-sm transition-colors duration-200 cursor-default hover:bg-blue-100">
+                <MapPin className="w-4 h-4 text-blue-400" />
+                {review.travels.name_kr}
+              </Badge>
+              <span className="text-xs text-gray-400">
+                {(() => {
+                  const d = new Date(review.created_at);
+                  const yyyy = d.getFullYear();
+                  const mm = String(d.getMonth() + 1).padStart(2, '0');
+                  const dd = String(d.getDate()).padStart(2, '0');
+                  const hh = String(d.getHours()).padStart(2, '0');
+                  const min = String(d.getMinutes()).padStart(2, '0');
+                  return `${yyyy}.${mm}.${dd} ${hh}:${min}`;
+                })()}
+              </span>
             </div>
-            <div className="flex items-center space-x-2">
-              {!isEditing && (
-                <div className="flex items-center space-x-1">
+          </div>
+          <div className="ml-auto flex items-center gap-1">
+            {/* 별점 */}
+            {!isEditing && (
+              <div className="flex items-center space-x-1">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <span key={star} className="relative inline-block">
+                    <Star className="h-4 w-4 text-gray-300" />
+                    {review.score >= star && (
+                      <Star className="h-4 w-4 text-yellow-400 fill-current absolute left-0 top-0" />
+                    )}
+                    {review.score >= star - 0.5 && review.score < star && (
+                      <span
+                        className="absolute left-0 top-0 overflow-hidden"
+                        style={{ width: '50%' }}
+                      >
+                        <Star className="h-4 w-4 text-yellow-400 fill-current" />
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            )}
+            {isEditing && editState && (
+              <div className="flex flex-col space-y-1 items-end">
+                <div className="flex space-x-1">
                   {[1, 2, 3, 4, 5].map((star) => (
-                    <span key={star} className="relative inline-block">
-                      <Star className="h-4 w-4 text-gray-300" />
-                      {review.score >= star && (
-                        <Star className="h-4 w-4 text-yellow-400 fill-current absolute left-0 top-0" />
-                      )}
-                      {review.score >= star - 0.5 && review.score < star && (
-                        <span
-                          className="absolute left-0 top-0 overflow-hidden"
-                          style={{ width: '50%' }}
-                        >
-                          <Star className="h-4 w-4 text-yellow-400 fill-current" />
-                        </span>
-                      )}
-                    </span>
+                    <div key={star} className="relative">
+                      <div
+                        className="cursor-pointer"
+                        onClick={(e) => {
+                          const rect = (e.target as HTMLElement).getBoundingClientRect();
+                          const clickX = (e as any).clientX - rect.left;
+                          const isLeftHalf = clickX < rect.width / 2;
+                          const newScore = isLeftHalf ? star - 0.5 : star;
+                          editState.setEditScore(newScore);
+                        }}
+                      >
+                        <Star className="h-4 w-4 text-gray-300" />
+                        {editState.editScore >= star && (
+                          <div className="absolute inset-0 pointer-events-none">
+                            <Star className="h-4 w-4 text-yellow-400 fill-current" />
+                          </div>
+                        )}
+                        {editState.editScore >= star - 0.5 && editState.editScore < star && (
+                          <div
+                            className="absolute inset-0 overflow-hidden pointer-events-none"
+                            style={{ width: '50%' }}
+                          >
+                            <Star className="h-4 w-4 text-yellow-400 fill-current" />
+                          </div>
+                        )}
+                      </div>
+                    </div>
                   ))}
                 </div>
+                <p className="text-sm text-gray-500">현재 선택된 평점: {editState.editScore}</p>
+              </div>
+            )}
+            {isMine && !isEditing && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0 text-blue-500 hover:text-blue-700 hover:bg-blue-50"
+                  onClick={onEdit}
+                >
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50"
+                  onClick={onDelete}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+        {/* 본문 내용 */}
+        {!isEditing && (
+          <div className="text-gray-700 mb-3 leading-relaxed break-words">{review.content}</div>
+        )}
+        {/* 수정 모드 UI 등은 기존대로 */}
+        {isEditing && editState ? (
+          <div className="space-y-2">
+            {/* 이미지 처리 옵션 */}
+            <label className="block text-sm font-medium">이미지 처리</label>
+            {/* 기존 이미지 미리보기 */}
+            {review.review_img.length > 0 && (
+              <div className="mb-2">
+                <p className="text-sm text-gray-600 mb-1">현재 이미지:</p>
+                <div className="flex space-x-2">
+                  {review.review_img.map((img, index) => (
+                    <img
+                      key={index}
+                      src={img.img_url}
+                      alt="기존 이미지"
+                      className="w-16 h-16 object-cover rounded border"
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="flex space-x-4">
+              <label className="flex items-center space-x-1">
+                <input
+                  type="radio"
+                  name={`imageAction-${review.id}`}
+                  value="keep"
+                  checked={editState.imageAction === 'keep'}
+                  onChange={() => editState.setImageAction('keep')}
+                />
+                <span>기존 이미지 유지</span>
+              </label>
+              <label className="flex items-center space-x-1">
+                <input
+                  type="radio"
+                  name={`imageAction-${review.id}`}
+                  value="replace"
+                  checked={editState.imageAction === 'replace'}
+                  onChange={() => editState.setImageAction('replace')}
+                />
+                <span>새 이미지로 교체</span>
+              </label>
+              {review.review_img.length > 0 && (
+                <label className="flex items-center space-x-1">
+                  <input
+                    type="radio"
+                    name={`imageAction-${review.id}`}
+                    value="remove"
+                    checked={editState.imageAction === 'remove'}
+                    onChange={() => editState.setImageAction('remove')}
+                  />
+                  <span>이미지 삭제</span>
+                </label>
               )}
-              {isEditing && editState && (
-                <div className="flex flex-col space-y-1 items-end">
-                  <div className="flex space-x-1">
-                    {[1, 2, 3, 4, 5].map((star) => (
-                      <div key={star} className="relative">
-                        <div
-                          className="cursor-pointer"
-                          onClick={(e) => {
-                            const rect = (e.target as HTMLElement).getBoundingClientRect();
-                            const clickX = (e as any).clientX - rect.left;
-                            const isLeftHalf = clickX < rect.width / 2;
-                            const newScore = isLeftHalf ? star - 0.5 : star;
-                            editState.setEditScore(newScore);
+            </div>
+            {/* 새 이미지 업로드 */}
+            {editState.imageAction === 'replace' && (
+              <div className="space-y-2">
+                {editState.editImages.length > 0 && (
+                  <div className="flex space-x-2 mb-2">
+                    {editState.editImages.map((file, index) => (
+                      <div key={index} className="relative">
+                        <img
+                          src={URL.createObjectURL(file)}
+                          alt="새 이미지 미리보기"
+                          className="w-16 h-16 object-cover rounded border"
+                        />
+                        <button
+                          onClick={() => {
+                            editState.setEditImages([]);
+                            if (editState.editFileInputRef.current) {
+                              editState.editFileInputRef.current.value = '';
+                            }
                           }}
+                          className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
                         >
-                          <Star className="h-4 w-4 text-gray-300" />
-                          {editState.editScore >= star && (
-                            <div className="absolute inset-0 pointer-events-none">
-                              <Star className="h-4 w-4 text-yellow-400 fill-current" />
-                            </div>
-                          )}
-                          {editState.editScore >= star - 0.5 && editState.editScore < star && (
-                            <div
-                              className="absolute inset-0 overflow-hidden pointer-events-none"
-                              style={{ width: '50%' }}
-                            >
-                              <Star className="h-4 w-4 text-yellow-400 fill-current" />
-                            </div>
-                          )}
-                        </div>
+                          ×
+                        </button>
                       </div>
                     ))}
                   </div>
-                  <p className="text-sm text-gray-500">현재 선택된 평점: {editState.editScore}</p>
-                </div>
-              )}
-              {isMine && !isEditing && (
-                <>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0 text-blue-500 hover:text-blue-700 hover:bg-blue-50"
-                    onClick={onEdit}
-                  >
-                    <Edit className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50"
-                    onClick={onDelete}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </>
-              )}
+                )}
+                <Input
+                  type="file"
+                  accept=".png,.jpg,.jpeg,.webp"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
+                    const maxSize = 5 * 1024 * 1024;
+                    if (!allowedTypes.includes(file.type)) {
+                      if (editState.editFileInputRef.current)
+                        editState.editFileInputRef.current.value = '';
+                      alert('png, jpg, webp 파일만 업로드할 수 있습니다.');
+                      return;
+                    }
+                    if (file.size > maxSize) {
+                      if (editState.editFileInputRef.current)
+                        editState.editFileInputRef.current.value = '';
+                      alert('파일 크기는 5MB를 넘을 수 없습니다.');
+                      return;
+                    }
+                    editState.setEditImages([file]);
+                  }}
+                  ref={editState.editFileInputRef}
+                />
+              </div>
+            )}
+            {/* 이미지 삭제 경고 */}
+            {editState.imageAction === 'remove' && (
+              <p className="text-sm text-red-600 bg-red-50 p-2 rounded">
+                ⚠️ 이미지를 삭제하면 복구할 수 없습니다.
+              </p>
+            )}
+            {/* 후기 내용/버튼 */}
+            <Input
+              value={editState.editContent}
+              onChange={(e) => editState.setEditContent(e.target.value)}
+              placeholder="수정할 내용을 입력하세요"
+            />
+            <div className="flex justify-end space-x-2">
+              <Button variant="outline" onClick={onEditCancel}>
+                수정 취소
+              </Button>
+              <Button onClick={onEditSubmit}>수정 완료</Button>
             </div>
           </div>
-        </CardHeader>
-        <CardContent className="p-0 pt-2">
-          {isEditing && editState ? (
-            <div className="space-y-2">
-              {/* 이미지 처리 옵션 */}
-              <label className="block text-sm font-medium">이미지 처리</label>
-              {/* 기존 이미지 미리보기 */}
-              {review.review_img.length > 0 && (
-                <div className="mb-2">
-                  <p className="text-sm text-gray-600 mb-1">현재 이미지:</p>
-                  <div className="flex space-x-2">
-                    {review.review_img.map((img, index) => (
-                      <img
-                        key={index}
-                        src={img.img_url}
-                        alt="기존 이미지"
-                        className="w-16 h-16 object-cover rounded border"
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-              <div className="flex space-x-4">
-                <label className="flex items-center space-x-1">
-                  <input
-                    type="radio"
-                    name={`imageAction-${review.id}`}
-                    value="keep"
-                    checked={editState.imageAction === 'keep'}
-                    onChange={() => editState.setImageAction('keep')}
-                  />
-                  <span>기존 이미지 유지</span>
-                </label>
-                <label className="flex items-center space-x-1">
-                  <input
-                    type="radio"
-                    name={`imageAction-${review.id}`}
-                    value="replace"
-                    checked={editState.imageAction === 'replace'}
-                    onChange={() => editState.setImageAction('replace')}
-                  />
-                  <span>새 이미지로 교체</span>
-                </label>
-                {review.review_img.length > 0 && (
-                  <label className="flex items-center space-x-1">
-                    <input
-                      type="radio"
-                      name={`imageAction-${review.id}`}
-                      value="remove"
-                      checked={editState.imageAction === 'remove'}
-                      onChange={() => editState.setImageAction('remove')}
-                    />
-                    <span>이미지 삭제</span>
-                  </label>
-                )}
-              </div>
-              {/* 새 이미지 업로드 */}
-              {editState.imageAction === 'replace' && (
-                <div className="space-y-2">
-                  {editState.editImages.length > 0 && (
-                    <div className="flex space-x-2 mb-2">
-                      {editState.editImages.map((file, index) => (
-                        <div key={index} className="relative">
-                          <img
-                            src={URL.createObjectURL(file)}
-                            alt="새 이미지 미리보기"
-                            className="w-16 h-16 object-cover rounded border"
-                          />
-                          <button
-                            onClick={() => {
-                              editState.setEditImages([]);
-                              if (editState.editFileInputRef.current) {
-                                editState.editFileInputRef.current.value = '';
-                              }
-                            }}
-                            className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  <Input
-                    type="file"
-                    accept=".png,.jpg,.jpeg,.webp"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (!file) return;
-                      const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
-                      const maxSize = 5 * 1024 * 1024;
-                      if (!allowedTypes.includes(file.type)) {
-                        if (editState.editFileInputRef.current)
-                          editState.editFileInputRef.current.value = '';
-                        alert('png, jpg, webp 파일만 업로드할 수 있습니다.');
-                        return;
-                      }
-                      if (file.size > maxSize) {
-                        if (editState.editFileInputRef.current)
-                          editState.editFileInputRef.current.value = '';
-                        alert('파일 크기는 5MB를 넘을 수 없습니다.');
-                        return;
-                      }
-                      editState.setEditImages([file]);
-                    }}
-                    ref={editState.editFileInputRef}
-                  />
-                </div>
-              )}
-              {/* 이미지 삭제 경고 */}
-              {editState.imageAction === 'remove' && (
-                <p className="text-sm text-red-600 bg-red-50 p-2 rounded">
-                  ⚠️ 이미지를 삭제하면 복구할 수 없습니다.
-                </p>
-              )}
-              {/* 후기 내용/버튼 */}
-              <Input
-                value={editState.editContent}
-                onChange={(e) => editState.setEditContent(e.target.value)}
-                placeholder="수정할 내용을 입력하세요"
-              />
-              <div className="flex justify-end space-x-2">
-                <Button variant="outline" onClick={onEditCancel}>
-                  수정 취소
-                </Button>
-                <Button onClick={onEditSubmit}>수정 완료</Button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <p className="text-gray-700 mb-4 leading-relaxed">{review.content}</p>
-              <div className="flex justify-end mt-2">
-                <span className="text-xs text-gray-400">
-                  {(() => {
-                    const d = new Date(review.created_at);
-                    const yyyy = d.getFullYear();
-                    const mm = String(d.getMonth() + 1).padStart(2, '0');
-                    const dd = String(d.getDate()).padStart(2, '0');
-                    const hh = String(d.getHours()).padStart(2, '0');
-                    const min = String(d.getMinutes()).padStart(2, '0');
-                    return `${yyyy}.${mm}.${dd} ${hh}:${min}`;
-                  })()}
-                </span>
-              </div>
-            </>
-          )}
-        </CardContent>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 후기 페이지네이션 적용

## ✨ 주요 변경 사항

- components/ui 내에 있는 pagination 컴포넌트 활용함
- 후기 리스트 출력 시 한 페이지당 최대 10개 까지의 후기 출력 후 페이지로 분리
- 아래의 페이지 숫자 또는 이동 버튼을 누르면 페이지 이동

---

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 실행 테스트 완료
- [x] 코드 스타일(Prettier 등) 확인 및 적용
- [x] 불필요한 콘솔/주석 제거

---

## 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| (캡처)  | <img width="1185" height="339" alt="image" src="https://github.com/user-attachments/assets/2f8414d1-f6b2-495e-b519-2544fd7f2d0e" />  |

---

## 기타 참고 사항 (선택)

- 무한 스크롤 방식으로의 구현도 고려 할 만 함
